### PR TITLE
fixed 'logger.clear is not a function' issue for ^1.5.0 bundler version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
-const logger = require('parcel-bundler/src/Logger');
+const Logger = require('parcel-bundler/src/Logger');
 const mkdirp = require('mkdirp');
 const jsonfile = require('jsonfile');
 const constFile = require('./src/const');
 
 mkdirp.sync(constFile.cacheDir);
+const logger = new Logger({});
 
 module.exports = function (bundler) {
     jsonfile.writeFileSync(constFile.cacheFile, {});
 
     bundler.addAssetType('js', require.resolve('./src/EslintAsset.js'));
-    // bundler.addPackager('vue', require.resolve('./MyPackager'));
 
     bundler.on('bundled', () => {
         let cache;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-eslint",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Hi!

I was using parcel 1.5.x as in current package dependencies in my pet project and tried to install the plugin.

Unfortantely, it kept throwing me the error:
![image](https://user-images.githubusercontent.com/4013091/48677869-6fe49400-eb8c-11e8-9f57-551834abdfe8.png)

After small digging I found out that recent logger implementations are expecting the class to be referenced and therefore be instantiated accordingly.
https://github.com/parcel-bundler/parcel/blob/4773d65e7e3d012cb1f7350ad1bac6effd9d8832/packages/core/logger/src/Logger.js

so... suggesting a tiny fix, hope you don't mind.

After it it worked like a charm for me (hence, more linting efforts U__U), hope I won't break anything else for other guys.