### PR TITLE
fix logger not found error in latest parcel

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const logger = require('parcel-bundler/src/Logger');
+const logger = require('@parcel/logger');
 const mkdirp = require('mkdirp');
 const jsonfile = require('jsonfile');
 const constFile = require('./src/const');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "eslint": "~4",
-    "parcel-bundler": "~1"
+    "parcel-bundler": ">=1.11.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",


### PR DESCRIPTION
fixes `Cannot find module 'parcel-bundler/src/Logger'`

parcel is now a monorepo, logger was moved to `@parcel/logger`